### PR TITLE
Patch 2

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -154,5 +154,11 @@ TW_HAS_MTP := true
 # Debug
 TWRP_INCLUDE_LOGCAT := true
 TARGET_USES_LOGD := true
+# Tools
+TW_INCLUDE_FB2PNG := true
+TW_INCLUDE_FUSE_EXFAT := true
+TW_INCLUDE_NTFS_3G := true
+TW_INCLUDE_LIBRESETPROP := true
+TW_INCLUDE_LPTOOLS := true
 
 TW_DEVICE_VERSION := cd-Crypton-akifakif32

--- a/recovery/root/system/etc/twrp.flags
+++ b/recovery/root/system/etc/twrp.flags
@@ -55,7 +55,8 @@
 /otp                      emmc      /dev/block/by-name/otp                                 flags=display=otp
 /tkv                      emmc      /dev/block/by-name/tkv                                 flags=display=tkv
 # Flashable logical partitions
-/system_image             emmc      /dev/block/bootdevice/by-name/system             flags=display="System Image";backup=1;flashimg=1;slotselect
-/vendor_image             emmc      /dev/block/bootdevice/by-name/vendor             flags=display="Vendor Image";backup=1;flashimg=1;slotselect
-/system_ext_image         emmc      /dev/block/bootdevice/by-name/system_ext         flags=display="System_EXT Image";backup=1;flashimg=1;slotselect
-/product_image            emmc      /dev/block/bootdevice/by-name/product            flags=display="Product Image";backup=1;flashimg=1;slotselect
+/system_image       emmc  /dev/block/mapper/system                       flags=backup=1;display="System Image";slotselect;flashimg=1
+/system_ext_image   emmc  /dev/block/mapper/system_ext                   flags=backup=1;display="System_ext Image";slotselect;flashimg=1
+/vendor_image       emmc  /dev/block/mapper/vendor                       flags=backup=1;display="Vendor Image";slotselect;flashimg=1
+/product_image      emmc  /dev/block/mapper/product                      flags=backup=1;display="Product Image";slotselect;flashimg=1
+/odm_image          emmc  /dev/block/mapper/odm_dlkm                     flags=backup=1;display="ODM Image";slotselect;flashimg=1

--- a/recovery/root/system/etc/twrp.flags
+++ b/recovery/root/system/etc/twrp.flags
@@ -54,3 +54,8 @@
 /dtbo                     emmc      /dev/block/by-name/dtbo                                flags=display=dtbo;backup=1;flashimg=1;slotselect
 /otp                      emmc      /dev/block/by-name/otp                                 flags=display=otp
 /tkv                      emmc      /dev/block/by-name/tkv                                 flags=display=tkv
+# Flashable logical partitions
+/system_image             emmc      /dev/block/bootdevice/by-name/system             flags=display="System Image";backup;flashimg
+/vendor_image             emmc      /dev/block/bootdevice/by-name/vendor             flags=display="Vendor Image";backup;flashimg
+/system_ext_image         emmc      /dev/block/bootdevice/by-name/system_ext         flags=display="System_EXT Image";backup;flashimg
+/product_image            emmc      /dev/block/bootdevice/by-name/product            flags=display="Product Image";backup;flashimg

--- a/recovery/root/system/etc/twrp.flags
+++ b/recovery/root/system/etc/twrp.flags
@@ -55,7 +55,7 @@
 /otp                      emmc      /dev/block/by-name/otp                                 flags=display=otp
 /tkv                      emmc      /dev/block/by-name/tkv                                 flags=display=tkv
 # Flashable logical partitions
-/system_image             emmc      /dev/block/bootdevice/by-name/system             flags=display="System Image";backup;flashimg
-/vendor_image             emmc      /dev/block/bootdevice/by-name/vendor             flags=display="Vendor Image";backup;flashimg
-/system_ext_image         emmc      /dev/block/bootdevice/by-name/system_ext         flags=display="System_EXT Image";backup;flashimg
-/product_image            emmc      /dev/block/bootdevice/by-name/product            flags=display="Product Image";backup;flashimg
+/system_image             emmc      /dev/block/bootdevice/by-name/system             flags=display="System Image";backup=1;flashimg=1;slotselect
+/vendor_image             emmc      /dev/block/bootdevice/by-name/vendor             flags=display="Vendor Image";backup=1;flashimg=1;slotselect
+/system_ext_image         emmc      /dev/block/bootdevice/by-name/system_ext         flags=display="System_EXT Image";backup=1;flashimg=1;slotselect
+/product_image            emmc      /dev/block/bootdevice/by-name/product            flags=display="Product Image";backup=1;flashimg=1;slotselect

--- a/twrp_X6710.mk
+++ b/twrp_X6710.mk
@@ -9,6 +9,9 @@
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base_telephony.mk)
 
+# Installs gsi keys into ramdisk, to boot a developer GSI with verified boot.
+$(call inherit-product, $(SRC_TARGET_DIR)/product/gsi_keys.mk)
+
 # Inherit some common Omni stuff.
 $(call inherit-product, vendor/twrp/config/common.mk)
 


### PR DESCRIPTION
# Installs gsi keys into ramdisk, to boot a developer GSI with verified boot.
$(call inherit-product, $(SRC_TARGET_DIR)/product/gsi_keys.mk)
Acording https://4pda.to/forum/index.php?showtopic=636604&view=findpost&p=126305043